### PR TITLE
140: Fix LongitudinalGSF 

### DIFF
--- a/R/LinkGSF.R
+++ b/R/LinkGSF.R
@@ -137,7 +137,7 @@ link_gsf_abstract <- function(stan,
 link_gsf_ttg <- function(
         gamma = prior_normal(0, 5, init = 0)
 ) {
-    link_gsf_abstract(
+    .link_gsf_ttg(
         stan = StanModule("lm-gsf/link_ttg.stan"),
         parameter = ParameterList(Parameter(name = "lm_gsf_gamma", prior = gamma, size = 1)),
         parameter_name = "lm_gsf_gamma",
@@ -167,9 +167,9 @@ link_gsf_ttg <- function(
 #'
 #' @export
 link_gsf_dsld <- function(
-        beta = Parameter(prior_normal(0, 5, init = 0))
+        beta = prior_normal(0, 5, init = 0)
 ) {
-    link_gsf_abstract(
+    .link_gsf_dsld(
         stan = StanModule("lm-gsf/link_dsld.stan"),
         parameter = ParameterList(Parameter(name = "lm_gsf_beta", prior = beta, size = 1)),
         parameter_name = "lm_gsf_beta",

--- a/R/LongitudinalGSF.R
+++ b/R/LongitudinalGSF.R
@@ -36,14 +36,14 @@ NULL
 #' @export
 LongitudinalGSF <- function(
     mu_bsld = prior_lognormal(log(55), 5, init = 55),
-    mu_ks = prior_lognormal(0, 0.5, init = 0.01),
-    mu_kg = prior_lognormal(-0.36, 1, init = 0.01),
+    mu_ks = prior_lognormal(log(0.1), 0.5, init = 0.1),
+    mu_kg = prior_lognormal(log(0.1), 1, init = 0.1),
     mu_phi = prior_beta(2, 8, init = 0.2),
-    omega_bsld = prior_lognormal(0, 1, init = 0.001),
-    omega_ks = prior_lognormal(0, 1, init = 0.001),
-    omega_kg = prior_lognormal(0, 1, init = 0.001),
-    omega_phi = prior_lognormal(0, 1, init = 0.001),
-    sigma = prior_lognormal(-1.6, 0.8, init = 0.1)
+    omega_bsld = prior_lognormal(log(0.1), 1, init = 0.1),
+    omega_ks = prior_lognormal(log(0.1), 1, init = 0.1),
+    omega_kg = prior_lognormal(log(0.1), 1, init = 0.1),
+    omega_phi = prior_lognormal(log(0.1), 1, init = 0.1),
+    sigma = prior_lognormal(log(0.1), 0.8, init = 0.1)
 ) {
     eta_prior <- prior_normal(0, 1)
     x <- LongitudinalModel(

--- a/R/LongitudinalGSF.R
+++ b/R/LongitudinalGSF.R
@@ -36,14 +36,14 @@ NULL
 #' @export
 LongitudinalGSF <- function(
     mu_bsld = prior_lognormal(log(55), 5, init = 55),
-    mu_ks = prior_lognormal(0, 0.5, init = 0),
-    mu_kg = prior_lognormal(-0.36, 1, init = -0.36),
+    mu_ks = prior_lognormal(0, 0.5, init = 0.01),
+    mu_kg = prior_lognormal(-0.36, 1, init = 0.01),
     mu_phi = prior_beta(2, 8, init = 0.2),
-    omega_bsld = prior_lognormal(0, 1, init = 0),
-    omega_ks = prior_lognormal(0, 1, init = 0),
-    omega_kg = prior_lognormal(0, 1, init = 0),
-    omega_phi = prior_lognormal(0, 1, init = 0),
-    sigma = prior_lognormal(-1.6, 0.8, init = -1.6)
+    omega_bsld = prior_lognormal(0, 1, init = 0.001),
+    omega_ks = prior_lognormal(0, 1, init = 0.001),
+    omega_kg = prior_lognormal(0, 1, init = 0.001),
+    omega_phi = prior_lognormal(0, 1, init = 0.001),
+    sigma = prior_lognormal(-1.6, 0.8, init = 0.1)
 ) {
     eta_prior <- prior_normal(0, 1)
     x <- LongitudinalModel(

--- a/R/SurvivalLoglogistic.R
+++ b/R/SurvivalLoglogistic.R
@@ -24,7 +24,7 @@ NULL
 #'
 #' @export
 SurvivalLogLogistic <- function(
-         lambda = prior_lognormal(0, 5, init = 1 / 200),
+         lambda = prior_lognormal(log(0.1), 5, init = 0.1),
          p = prior_gamma(2, 5, init = 0.5),
          beta = prior_normal(0, 5)
 ) {

--- a/man/LongitudinalGSF-class.Rd
+++ b/man/LongitudinalGSF-class.Rd
@@ -9,14 +9,14 @@
 \usage{
 LongitudinalGSF(
   mu_bsld = prior_lognormal(log(55), 5, init = 55),
-  mu_ks = prior_lognormal(0, 0.5, init = 0),
-  mu_kg = prior_lognormal(-0.36, 1, init = -0.36),
+  mu_ks = prior_lognormal(0, 0.5, init = 0.01),
+  mu_kg = prior_lognormal(-0.36, 1, init = 0.01),
   mu_phi = prior_beta(2, 8, init = 0.2),
-  omega_bsld = prior_lognormal(0, 1, init = 0),
-  omega_ks = prior_lognormal(0, 1, init = 0),
-  omega_kg = prior_lognormal(0, 1, init = 0),
-  omega_phi = prior_lognormal(0, 1, init = 0),
-  sigma = prior_lognormal(-1.6, 0.8, init = -1.6)
+  omega_bsld = prior_lognormal(0, 1, init = 0.001),
+  omega_ks = prior_lognormal(0, 1, init = 0.001),
+  omega_kg = prior_lognormal(0, 1, init = 0.001),
+  omega_phi = prior_lognormal(0, 1, init = 0.001),
+  sigma = prior_lognormal(-1.6, 0.8, init = 0.1)
 )
 }
 \arguments{

--- a/man/LongitudinalGSF-class.Rd
+++ b/man/LongitudinalGSF-class.Rd
@@ -9,14 +9,14 @@
 \usage{
 LongitudinalGSF(
   mu_bsld = prior_lognormal(log(55), 5, init = 55),
-  mu_ks = prior_lognormal(0, 0.5, init = 0.01),
-  mu_kg = prior_lognormal(-0.36, 1, init = 0.01),
+  mu_ks = prior_lognormal(log(0.1), 0.5, init = 0.1),
+  mu_kg = prior_lognormal(log(0.1), 1, init = 0.1),
   mu_phi = prior_beta(2, 8, init = 0.2),
-  omega_bsld = prior_lognormal(0, 1, init = 0.001),
-  omega_ks = prior_lognormal(0, 1, init = 0.001),
-  omega_kg = prior_lognormal(0, 1, init = 0.001),
-  omega_phi = prior_lognormal(0, 1, init = 0.001),
-  sigma = prior_lognormal(-1.6, 0.8, init = 0.1)
+  omega_bsld = prior_lognormal(log(0.1), 1, init = 0.1),
+  omega_ks = prior_lognormal(log(0.1), 1, init = 0.1),
+  omega_kg = prior_lognormal(log(0.1), 1, init = 0.1),
+  omega_phi = prior_lognormal(log(0.1), 1, init = 0.1),
+  sigma = prior_lognormal(log(0.1), 0.8, init = 0.1)
 )
 }
 \arguments{

--- a/man/SurvivalLogLogistic-class.Rd
+++ b/man/SurvivalLogLogistic-class.Rd
@@ -8,7 +8,7 @@
 \title{\code{SurvivalLogLogistic}}
 \usage{
 SurvivalLogLogistic(
-  lambda = prior_lognormal(0, 5, init = 1/200),
+  lambda = prior_lognormal(log(0.1), 5, init = 0.1),
   p = prior_gamma(2, 5, init = 0.5),
   beta = prior_normal(0, 5)
 )

--- a/man/expand_initial_values.Rd
+++ b/man/expand_initial_values.Rd
@@ -10,14 +10,19 @@ expand_initial_values(initial_values, sizes)
 \item{initial_values}{(\code{list})\cr initial values with names.}
 
 \item{sizes}{(\code{list})\cr each size corresponds to an element in \code{initial_values},
-matched by the names.}
+matched by the names. An attribute \code{array} must be attached to each element,
+see \code{\link[=replace_with_lookup]{replace_with_lookup()}}.}
 }
 \value{
 A named list of values, with any single values in the \code{initial_values} list
 replicated according to the corresponding values in the \code{sizes} list.
-The resulting list has the same names as the original lists.
+Even when the size is 1, the value is passed as an \code{array} if the corresponding
+attribute is \code{TRUE} in \code{sizes}.
 }
 \description{
 Replicate Single Values in a List
+}
+\note{
+The resulting list has the same names as the original lists.
 }
 \keyword{internal}

--- a/man/link_gsf_dsld-class.Rd
+++ b/man/link_gsf_dsld-class.Rd
@@ -7,7 +7,7 @@
 \alias{link_gsf_dsld}
 \title{\code{link_gsf_dsld}}
 \usage{
-link_gsf_dsld(beta = Parameter(prior_normal(0, 5, init = 0)))
+link_gsf_dsld(beta = prior_normal(0, 5, init = 0))
 }
 \arguments{
 \item{beta}{(\code{Prior})\cr prior for the link coefficient \code{beta}.}

--- a/man/replace_with_lookup.Rd
+++ b/man/replace_with_lookup.Rd
@@ -19,6 +19,13 @@ replaced by their corresponding numeric values in \code{data}.
 \description{
 Replace Character Size by Looked Up Numbers
 }
+\details{
+An attribute \code{array} for each returned list element indicates
+whether the parameter needs to be handled
+as an array. This is the case when the size is larger than 1, or when
+the size was looked up in the \code{data}, because in that case it is flexible
+and hence is handled as an array in the Stan code.
+}
 \note{
 Each element in the final list of sizes must be a single number.
 }

--- a/tests/testthat/test-LinkGSF.R
+++ b/tests/testthat/test-LinkGSF.R
@@ -1,0 +1,27 @@
+# LinkGSF-class ----
+
+test_that("LinkGSF class initialization works as expected", {
+    result <- expect_silent(.LinkGSF())
+    expect_s4_class(result, "LinkGSF")
+})
+
+# LinkGSF-constructors ----
+
+test_that("LinkGSF user constructor works as expected with defaults", {
+    result <- expect_silent(LinkGSF())
+    expect_s4_class(result, "LinkGSF")
+})
+
+# link_gsf_ttg-constructors ----
+
+test_that("link_gsf_ttg user constructor works as expected with defaults", {
+    result <- expect_silent(link_gsf_ttg())
+    expect_s4_class(result, "link_gsf_ttg")
+})
+
+# link_gsf_dsld-constructors ----
+
+test_that("link_gsf_dsld user constructor works as expected with defaults", {
+    result <- expect_silent(link_gsf_dsld())
+    expect_s4_class(result, "link_gsf_dsld")
+})

--- a/tests/testthat/test-LongitudinalGSF.R
+++ b/tests/testthat/test-LongitudinalGSF.R
@@ -1,0 +1,57 @@
+# LongitudinalGSF ----
+
+test_that("LongitudinalGSF works as expected with default arguments", {
+    result <- expect_silent(LongitudinalGSF())
+    expect_s4_class(result, "LongitudinalGSF")
+})
+
+test_that("LongitudinalGSF works as expected with a single study", {
+    set.seed(123)
+    jlist <- suppressMessages(simulate_joint_data(
+        lm_fun = sim_lm_random_slope(),
+        os_fun = sim_os_weibull(
+            lambda = 0.00333,  # 1/300
+            gamma = 0.97
+        )
+    ))
+
+    dat_os <- jlist$os
+    dat_lm <- jlist$lm |>
+        dplyr::filter(time %in% c(1, 50, 100, 150, 200, 250, 300)) |>
+        dplyr::arrange(time, pt)
+
+    jdat <- DataJoint(
+        survival = DataSurvival(
+            data = dat_os,
+            formula = Surv(time, event) ~ cov_cat + cov_cont,
+            subject = "pt",
+            arm = "arm",
+            study = "study"
+        ),
+        longitudinal = DataLongitudinal(
+            data = dat_lm,
+            formula = sld ~ time,
+            subject = "pt",
+            threshold = 5
+        )
+    )
+
+    jm <- JointModel(
+        link = LinkGSF(),
+        longitudinal = LongitudinalGSF(),
+        survival = SurvivalWeibullPH()
+    )
+
+    mp <- suppressWarnings(sampleStanModel(
+        jm,
+        data = jdat,
+        iter_sampling = 100,
+        iter_warmup = 100,
+        chains = 1,
+        parallel_chains = 1,
+        exe_file = tempfile()
+    ))
+
+    expect_s4_class(mp, "JointModelSamples")
+    expect_true(mp@results$summary("lm_gsf_mu_bsld")$ess_tail > 5)
+})

--- a/tests/testthat/test-LongitudinalGSF.R
+++ b/tests/testthat/test-LongitudinalGSF.R
@@ -10,7 +10,7 @@ test_that("LongitudinalGSF works as expected with a single study", {
     jlist <- suppressMessages(simulate_joint_data(
         lm_fun = sim_lm_random_slope(),
         os_fun = sim_os_weibull(
-            lambda = 0.00333,  # 1/300
+            lambda = 0.00333,
             gamma = 0.97
         )
     ))

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -47,30 +47,55 @@ test_that("remove_missing_rows works as expected", {
 
 # expand_initial_values ----
 
-test_that("expand_initial_values smoke tests", {
-    vals <- list("a" = 1, "b" = 2, "c" = c(1, 2))
-    siz <- list("a" = 5, "b" = 1, "c" = 2)
+test_that("expand_initial_values works as expected", {
+    vals <- list("a" = 1, "b" = 2, "c" = c(1, 2), "d" = 10)
+    siz <- list(
+        "a" = structure(5, array = TRUE),
+        "b" = structure(1, array = TRUE),
+        "c" = structure(2, array = TRUE),
+        "d" = structure(1, array = FALSE)
+    )
     actual <- expand_initial_values(vals, siz)
-    expected <- list("a" = c(1, 1, 1, 1, 1), "b" = 2, "c" = c(1, 2))
+    expected <- list(
+        "a" = as.array(c(1, 1, 1, 1, 1)),
+        "b" = as.array(2),
+        "c" = as.array(c(1, 2)),
+        "d" = 10
+    )
     expect_equal(actual, expected)
 })
 
 # replace_with_lookup ----
 
-test_that("replace_with_lookup smoke tests", {
-
-    vals <- list(1, "b", "a", 4, 5)
-    lku <- list("a" = 3, "b" = 2, "c" = 4)
+test_that("replace_with_lookup works and sets array attributes as expected", {
+    vals <- list(1, "b", "a", "d", 5)
+    lku <- list("a" = 3, "b" = 2, "c" = 4, "d" = 1)
     actual <- replace_with_lookup(vals, lku)
-    expected <- list(1, 2, 3, 4, 5)
+    expected <- list(
+        structure(1, array = FALSE),
+        structure(2, array = TRUE),
+        structure(3, array = TRUE),
+        structure(1, array = TRUE),
+        structure(5, array = TRUE)
+    )
     expect_equal(actual, expected)
+})
 
-
+test_that("replace_with_lookup asserts sizes as numbers as expected", {
     vals <- list(1, "b", "a", 4, c(5, 6))
     lku <- list("a" = 3, "b" = 2, "c" = 4)
     expect_error(
         replace_with_lookup(vals, lku),
-        regexp = "`sizes` must be a single number"
+        regexp = "Existing values in sizes must be single numbers"
+    )
+})
+
+test_that("replace_with_lookup asserts looked up sizes as numbers as expected", {
+    vals <- list(1, "b", "a", 4, 5)
+    lku <- list("a" = 3, "b" = c(2, 3), "c" = 1)
+    expect_error(
+        replace_with_lookup(vals, lku),
+        regexp = "Selected values from data must be single numbers"
     )
 })
 


### PR DESCRIPTION
closes #140

- adds `array` flag to each size so even single numbers will be passed as array when needed
- fixes initial values for `LongitudinalGSF` model
- fixes `link_gsf_dsld` default argument
- adds regression test for `LongitudinalGSF` sampling