### PR TITLE
Fix publishing of unit test and coverage reports

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -17,6 +17,13 @@ on:
       - develop
   workflow_dispatch:
 
+  # Rerun workflows once pkgdown has finished running, to add coverage
+  # and unit test report to gh-pages branch.
+  workflow_run:
+    workflows: ["Docs 📚"]
+    types:
+      - completed
+
 jobs:
   audit:
     name: Audit Dependencies 🕵️‍♂️

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,3 +37,25 @@ jobs:
     uses: insightsengineering/r.pkg.template/.github/workflows/release.yaml@main
     permissions:
       contents: write
+  r-cmd:
+    name: R CMD Check 🧬
+    needs: [release, docs]
+    uses: insightsengineering/r.pkg.template/.github/workflows/build-check-install.yaml@main
+    secrets:
+      REPO_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      additional-env-vars: |
+        CMDSTAN=/root/.cmdstan
+        CMDSTAN_PATH=/root/.cmdstan
+        CMDSTANR_NO_VER_CHECK=true
+  coverage:
+    name: Coverage 📔
+    needs: [release, docs]
+    uses: insightsengineering/r.pkg.template/.github/workflows/test-coverage.yaml@main
+    secrets:
+      REPO_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      additional-env-vars: |
+        CMDSTAN=/root/.cmdstan
+        CMDSTAN_PATH=/root/.cmdstan
+        CMDSTANR_NO_VER_CHECK=true


### PR DESCRIPTION
Retrigger Coverage and R CMD check workflows, once pkgdown workflow finishes running.
This is required to successfully publish the unit test and coverage reports to gh-pages.