### PR TITLE
added missing assertion

### DIFF
--- a/R/SurvivalQuantities.R
+++ b/R/SurvivalQuantities.R
@@ -71,6 +71,10 @@ SurvivalQuantities <- function(
     type <- match.arg(type)
     assert_class(object, "JointModelSamples")
     assert_class(grid, "Grid")
+    assert_that(
+        !is(grid, "GridPopulation"),
+        msg = "GridPopulation objects are not supported for `SurvivalQuantities`"
+    )
 
     time_grid <- seq(
         from = 0,

--- a/tests/testthat/test-Grid.R
+++ b/tests/testthat/test-Grid.R
@@ -696,3 +696,15 @@ test_that("GridPopulation() works as expected for Longitudinal models", {
     expect_equal(actual$group, expected$group)
 
 })
+
+test_that("GridPopulation() doesn't work with SurvivalQuantities", {
+    expect_error(
+        SurvivalQuantities(
+            fixtures_gsf$mp,
+            grid = GridPopulation(
+                times = seq(1, 4, by = 0.02)
+            )
+        ),
+        regex = "not supported"
+    )
+})


### PR DESCRIPTION
No corresponding issue, just realised after I merged the population code that I had forgot to put in the assertion that stops it being used with the `SurvivalQuantities` as it is not yet defined for them. 