### PR TITLE
Fix SF model not compiling

### DIFF
--- a/R/LongitudinalSteinFojo.R
+++ b/R/LongitudinalSteinFojo.R
@@ -124,7 +124,7 @@ enableLink.LongitudinalSteinFojo <- function(object, ...) {
 linkDSLD.LongitudinalSteinFojo <- function(prior = prior_normal(0, 2), model, ...) {
     LinkComponent(
         key = "link_dsld",
-        stan = StanModule("lm-sf/link_dsld.stan"),
+        stan = StanModule("lm-stein-fojo/link_dsld.stan"),
         prior = prior
     )
 }
@@ -133,7 +133,7 @@ linkDSLD.LongitudinalSteinFojo <- function(prior = prior_normal(0, 2), model, ..
 linkTTG.LongitudinalSteinFojo <- function(prior = prior_normal(0, 2), model, ...) {
     LinkComponent(
         key = "link_ttg",
-        stan = StanModule("lm-sf/link_ttg.stan"),
+        stan = StanModule("lm-stein-fojo/link_ttg.stan"),
         prior = prior
     )
 }
@@ -142,7 +142,7 @@ linkTTG.LongitudinalSteinFojo <- function(prior = prior_normal(0, 2), model, ...
 linkIdentity.LongitudinalSteinFojo <- function(prior = prior_normal(0, 2), model, ...) {
     LinkComponent(
         key = "link_identity",
-        stan = StanModule("lm-sf/link_identity.stan"),
+        stan = StanModule("lm-stein-fojo/link_identity.stan"),
         prior = prior
     )
 }

--- a/tests/testthat/test-LongitudinalGSF.R
+++ b/tests/testthat/test-LongitudinalGSF.R
@@ -25,7 +25,11 @@ test_that("Print method for LongitudinalGSF works as expected", {
 
 
 test_that("Centralised parameterisation compiles without issues", {
-    jm <- JointModel(longitudinal = LongitudinalGSF(centred = TRUE))
+    jm <- JointModel(
+        longitudinal = LongitudinalGSF(centred = TRUE),
+        survival = SurvivalWeibullPH(),
+        link = Link(linkTTG(), linkDSLD())
+    )
     expect_false(any(
         c("lm_gsf_eta_tilde_kg", "lm_gsf_eta_tilde_bsld") %in% names(jm@parameters)
     ))
@@ -34,12 +38,16 @@ test_that("Centralised parameterisation compiles without issues", {
     ))
     x <- as.StanModule(jm)
     x@generated_quantities <- ""
-    expect_stan_syntax(as.character(x))
+    expect_stan_syntax(x)
 })
 
 
 test_that("Non-Centralised parameterisation compiles without issues", {
-    jm <- JointModel(longitudinal = LongitudinalGSF(centred = FALSE))
+    jm <- JointModel(
+        longitudinal = LongitudinalGSF(centred = FALSE),
+        survival = SurvivalLogLogistic(),
+        link = linkDSLD()
+    )
     expect_true(all(
         c("lm_gsf_eta_tilde_kg", "lm_gsf_eta_tilde_bsld") %in% names(jm@parameters)
     ))
@@ -48,7 +56,7 @@ test_that("Non-Centralised parameterisation compiles without issues", {
     ))
     x <- as.StanModule(jm)
     x@generated_quantities <- ""
-    expect_stan_syntax(as.character(x))
+    expect_stan_syntax(x)
 })
 
 

--- a/tests/testthat/test-LongitudinalSteinFojo.R
+++ b/tests/testthat/test-LongitudinalSteinFojo.R
@@ -52,6 +52,44 @@ test_that("Non-Centralised parameterisation compiles without issues", {
 })
 
 
+
+test_that("Centralised parameterisation compiles without issues", {
+    jm <- JointModel(
+        longitudinal = LongitudinalSteinFojo(centred = TRUE),
+        survival = SurvivalExponential(),
+        link = Link(linkTTG(), linkDSLD())
+    )
+    expect_false(any(
+        c("lm_sf_eta_tilde_kg", "lm_sf_eta_tilde_bsld") %in% names(jm@parameters)
+    ))
+    expect_true(all(
+        c("lm_sf_psi_kg", "lm_sf_psi_bsld") %in% names(jm@parameters)
+    ))
+    x <- as.StanModule(jm)
+    x@generated_quantities <- ""
+    expect_stan_syntax(x)
+})
+
+
+test_that("Non-Centralised parameterisation compiles without issues", {
+    jm <- JointModel(
+        longitudinal = LongitudinalSteinFojo(centred = FALSE),
+        survival = SurvivalWeibullPH(),
+        link = Link()
+    )
+    expect_true(all(
+        c("lm_sf_eta_tilde_kg", "lm_sf_eta_tilde_bsld") %in% names(jm@parameters)
+    ))
+    expect_false(any(
+        c("lm_sf_psi_kg", "lm_sf_psi_bsld") %in% names(jm@parameters)
+    ))
+    x <- as.StanModule(jm)
+    x@generated_quantities <- ""
+    expect_stan_syntax(x)
+})
+
+
+
 test_that("Can recover known distributional parameters from a SF joint model", {
 
     skip_if_not(is_full_test())


### PR DESCRIPTION
Closes #310

Issue was due to an incorrect path name in the link function. Added additional unit tests to more explicitly test this.  I also slightly expanded the corresponding GSF tests to also check the link functions as well. 