### PR TITLE
Warnings for StanModules + cleanup

### DIFF
--- a/man/StanModule-class.Rd
+++ b/man/StanModule-class.Rd
@@ -7,15 +7,11 @@
 \alias{StanModule}
 \title{\code{StanModule} Object and Constructor Function}
 \usage{
-StanModule(x = "", priors = list(), inits = list(), ...)
+StanModule(x = "", ...)
 }
 \arguments{
 \item{x}{(\code{string})\cr file path to a Stan program or a character vector
 of Stan code to be parsed.}
-
-\item{priors}{(\code{list})\cr the prior specifications.}
-
-\item{inits}{(\code{list})\cr the initial values.}
 
 \item{...}{additional arguments passed to the constructor.}
 }
@@ -38,10 +34,6 @@ of Stan code to be parsed.}
 \item{\code{model}}{(\code{character})\cr the \code{model} block.}
 
 \item{\code{generated_quantities}}{(\code{character})\cr the \code{generated_quantities} block.}
-
-\item{\code{priors}}{(\code{list})\cr the prior specifications.}
-
-\item{\code{inits}}{(\code{list})\cr the initial values.}
 }}
 
 \seealso{

--- a/tests/testthat/test-StanModule.R
+++ b/tests/testthat/test-StanModule.R
@@ -195,3 +195,11 @@ test_that("StanModule.merge works as expected", {
     expect_equal(x@generated_quantities, c("    int w;", "    int z;"))
     expect_equal(x@functions, "")
 })
+
+
+test_that("StanModule() throws a warning if non-empty string generates empty object", {
+    expect_warning(
+        StanModule("adawd.stan"),
+        regex = "empty StanModule"
+    )
+})


### PR DESCRIPTION
Closes #324 

Decided to opt for a warning as I'm not sure it warranted a full error to be thrown.

I also took this opportunity to remove the `inits` and `prior` arguments to `StanModule`. These were based on an older design and are not currently used at all as both inits and priors are now handled by the `Parameter` / `ParameterList` system instead. I think this just got overlooked so am cleaning it up. 