### PR TITLE
Remove model cache

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -31,6 +31,10 @@ jobs:
         CMDSTAN=/root/.cmdstan
         CMDSTAN_PATH=/root/.cmdstan
         CMDSTANR_NO_VER_CHECK=true
+      ### Temporarily removed due to cache bug (#345)
+      #   JMPOST_CACHE_DIR=${{ github.workspace }}/.cache
+      # additional-caches: |
+      #   ${{ github.workspace }}/.cache
   coverage:
     name: Coverage 📔
     uses: insightsengineering/r.pkg.template/.github/workflows/test-coverage.yaml@main


### PR DESCRIPTION
Currently every other model run on GitHub actions is [failing](https://github.com/Genentech/jmpost/actions/runs/9398586560/job/25884227228) due to what I think is an issue with the GitHub cache. Theres no obvious reason as to why this is happening so will need to investigate at a later date. For now I'm just going to disable the GitHub cache so that the models are recompiled from scratch each time. 