### PR TITLE
Fix number of chains print method

### DIFF
--- a/R/JointModelSamples.R
+++ b/R/JointModelSamples.R
@@ -104,7 +104,7 @@ as_print_string.JointModelSamples <- function(object, indent = 1, ...) {
     sprintf(
         paste(template_padded, collapse = "\n"),
         as.CmdStanMCMC(object)$metadata()$iter_sampling,
-        as.CmdStanMCMC(object)$metadata()$num_chains
+        as.CmdStanMCMC(object)$num_chains()
     )
 }
 

--- a/tests/testthat/_snaps/JointModelSamples.md
+++ b/tests/testthat/_snaps/JointModelSamples.md
@@ -7,7 +7,7 @@
          JointModelSamples Object with:
         
             # of samples per chain = 100
-            # of chains            = 1
+            # of chains            = 2
         
             Variables:
                 Ypred[2800]

--- a/tests/testthat/_snaps/LongitudinalQuantiles.md
+++ b/tests/testthat/_snaps/LongitudinalQuantiles.md
@@ -10,7 +10,7 @@
     Output
       
        LongitudinalQuantities Object:
-          # of samples    = 100
+          # of samples    = 200
           # of quantities = 44 
       
 
@@ -24,7 +24,7 @@
     Output
       
        LongitudinalQuantities Object:
-          # of samples    = 100
+          # of samples    = 200
           # of quantities = 402 
       
 

--- a/tests/testthat/_snaps/SurvivalQuantities.md
+++ b/tests/testthat/_snaps/SurvivalQuantities.md
@@ -12,7 +12,7 @@
     Output
       
        SurvivalQuantities Object:
-          # of samples    = 100
+          # of samples    = 200
           # of quantities = 33
           Type            = surv 
       
@@ -27,7 +27,7 @@
     Output
       
        SurvivalQuantities Object:
-          # of samples    = 100
+          # of samples    = 200
           # of quantities = 4400
           Type            = loghaz 
       

--- a/tests/testthat/helper-example_data.R
+++ b/tests/testthat/helper-example_data.R
@@ -67,7 +67,7 @@ ensure_test_data_1 <- function() {
             data = jdat,
             iter_sampling = 100,
             iter_warmup = 150,
-            chains = 1,
+            chains = 2,
             refresh = 0,
             parallel_chains = 1
         )


### PR DESCRIPTION
Closes #356 

Minor side effect was that the main test object I have (which is shared across many tests) only used 1 chain so I had to increase that to 2 for the snapshots to show this change is working; but by doing so it impacted some other snapshot tests  which I had to update accordingly. 