### PR TITLE
fix brms test

### DIFF
--- a/tests/testthat/test-brms_compare.R
+++ b/tests/testthat/test-brms_compare.R
@@ -111,13 +111,13 @@ test_that("jmpost and brms get similar loo for longitudinal models", {
         ),
         data = dat,
         prior = c(
-            prior("normal(log(60), 0.6)", nlpar = "b"),
-            prior("normal(log(0.5), 0.6)", nlpar = "s"),
-            prior("normal(log(0.2), 0.6)", nlpar = "g"),
-            prior("lognormal(log(0.1), 0.6)", nlpar = "b", class = "sd"),
-            prior("lognormal(log(0.1), 0.6)", nlpar = "s", class = "sd"),
-            prior("lognormal(log(0.1), 0.6)", nlpar = "g", class = "sd"),
-            prior("lognormal(log(1.5), 0.6)", class = "sigma")
+            brms::prior("normal(log(60), 0.6)", nlpar = "b"),
+            brms::prior("normal(log(0.5), 0.6)", nlpar = "s"),
+            brms::prior("normal(log(0.2), 0.6)", nlpar = "g"),
+            brms::prior("lognormal(log(0.1), 0.6)", nlpar = "b", class = "sd"),
+            brms::prior("lognormal(log(0.1), 0.6)", nlpar = "s", class = "sd"),
+            brms::prior("lognormal(log(0.1), 0.6)", nlpar = "g", class = "sd"),
+            brms::prior("lognormal(log(1.5), 0.6)", class = "sigma")
         ),
         warmup = 1400,
         iter = 2600,
@@ -130,8 +130,8 @@ test_that("jmpost and brms get similar loo for longitudinal models", {
     #
     # Assert that loo scores are similar
     #
-    b_est <- brms::loo(mp_brms)
-    j_est <- stanmod$loo()
+    expect_warning(b_est <- brms::loo(mp_brms), "moment match")
+    expect_warning(j_est <- stanmod$loo(), "Pareto k diagnostic")
 
     z_score <- abs(b_est$estimates[, "Estimate"] - j_est$estimates[, "Estimate"]) / b_est$estimates[, "SE"]
     expect_true(all(z_score < qnorm(0.99)))


### PR DESCRIPTION
- Add `brms::` to `prior()` call
- Wrap warnings