### PR TITLE
Try roxylint with modified linter behavior for `param`/`typed` 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Encoding: UTF-8
 Language: en-GB
 URL: https://genentech.github.io/jmpost/
 BugReports: https://github.com/Genentech/jmpost/issues
-Roxygen: list(markdown = TRUE, packages = "roxytypes")
+Roxygen: list(markdown = TRUE, packages = "roxytypes", roclets = c("namespace", "rd", "roxylint::roxylint"))
 Depends: 
     R (>= 4.1.0)
 Imports: 
@@ -134,4 +134,4 @@ RdMacros: Rdpack
 LazyData: true
 Config/roxygen2/version: 8.0.0
 Config/Needs/documentation: 
-    roxytypes
+    roxytypes, roxylint

--- a/man/roxylint/meta.R
+++ b/man/roxylint/meta.R
@@ -4,6 +4,9 @@ list(
         param = function(x, ...) {
             roxylint::lint_full_stop(x, ...)
         },
+        typed = function(x, ...) {
+            roxylint::lint_full_stop(x, ...)
+        },
         return = roxylint::tidy_return,
         seealso = roxylint::tidy_seealso
     )

--- a/man/roxylint/meta.R
+++ b/man/roxylint/meta.R
@@ -1,7 +1,9 @@
 list(
     linters = list(
         title = roxylint::tidy_title,
-        param = roxylint::tidy_param,
+        param = function(x, ...) {
+            roxylint::lint_full_stop(x, ...)
+        },
         return = roxylint::tidy_return,
         seealso = roxylint::tidy_seealso
     )

--- a/man/roxylint/meta.R
+++ b/man/roxylint/meta.R
@@ -1,0 +1,8 @@
+list(
+    linters = list(
+        title = roxylint::tidy_title,
+        param = roxylint::tidy_param,
+        return = roxylint::tidy_return,
+        seealso = roxylint::tidy_seealso
+    )
+)


### PR DESCRIPTION
Trying to follow instructions in https://github.com/openpharma/roxylint - but somehowI don't get the modified behavior and no longer check sentence case for `param` or `typed`, but I am still seeing sentence case warnings. Here an excerpt from the "Document" log:

```
ℹ [settings.R:1] @title should be 'Sentence case'.
Found improperly cased word(s): 'jmpost'
ℹ [simulate.R:1] @title should be 'Sentence case'.
Found improperly cased word(s): 'Patients', 'Posterior', 'Predictive', 'Distribution'
ℹ [simulate.R:2] @param should terminate with a full stop
ℹ [simulate.R:12] @typed should be 'Sentence case'
ℹ [simulate.R:14] @typed should be 'Sentence case'
ℹ [simulate.R:16] @typed should be 'Sentence case'
ℹ [simulate.R:140] @param should terminate with a full stop
ℹ [simulate.R:141] @param should terminate with a full stop
ℹ [standalone-s3-register.R:47] @param should terminate with a full stop
```

